### PR TITLE
fix: missing cancel error

### DIFF
--- a/context.go
+++ b/context.go
@@ -48,8 +48,14 @@ func (rcv *groupCtx) Done() <-chan struct{} {
 	return rcv.group.C
 }
 
+// Err returns context.Canceled if the Done channel is closed or nil otherwise.
+// After Err returns a non-nil error, successive calls to Err return the same error.
+// The Err method is overridden to maintain the context.Canceled contract.
 func (rcv *groupCtx) Err() error {
-	return rcv.group.Err()
+	if rcv.group.IsSignalled() {
+		return context.Canceled
+	}
+	return nil
 }
 
 func (rcv *groupCtx) Value(key interface{}) interface{} {

--- a/group.go
+++ b/group.go
@@ -82,6 +82,7 @@ func (rcv *Group) Done(err error) {
 }
 
 // Err returns the first non-nil error (if any) specified in a call to Done.
+// After Err returns a non-nil error, successive calls to Err return the same error.
 func (rcv *Group) Err() error {
 	rcv.mu.Lock()
 	err := rcv.err


### PR DESCRIPTION
The contract for the groupCtx's Err method was inconsistent with context.Context.
This was causing a panic during cancellation.