### PR TITLE
feat: wait function with timeout

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
         platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 Reactive Markets Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import "errors"
+
+// ErrTimeout means that a timeout has occurred.
+var ErrTimeout = errors.New("timeout")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/reactive-go/task
 
-go 1.14
+go 1.15
 
-require github.com/stretchr/testify v1.5.1
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -3,9 +3,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/group_test.go
+++ b/group_test.go
@@ -16,6 +16,7 @@ package task_test
 
 import (
 	"errors"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -24,6 +25,22 @@ import (
 	"github.com/reactive-go/task"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGroupDoneNil(t *testing.T) {
+	group := task.NewGroup()
+	group.Add(1)
+	group.Done(nil)
+	err := group.Err()
+	assert.Nil(t, err)
+}
+
+func TestGroupDoneErr(t *testing.T) {
+	group := task.NewGroup()
+	group.Add(1)
+	group.Done(io.EOF)
+	err := group.Err()
+	assert.Equal(t, io.EOF, err)
+}
 
 func TestGroupSignal(t *testing.T) {
 	group := task.NewGroup()
@@ -44,6 +61,16 @@ func TestGroupSignal(t *testing.T) {
 
 	group.Wait()
 	assert.Equal(t, errTest, group.Err())
+}
+
+func TestGroupWaitTimeout(t *testing.T) {
+	group := task.NewGroup()
+	group.Add(1)
+	err := group.WaitTimeout(10 * time.Millisecond)
+	assert.Equal(t, task.ErrTimeout, err)
+	group.Done(nil)
+	err = group.Err()
+	assert.Nil(t, err)
 }
 
 func TestWaitGroup(t *testing.T) {

--- a/task_test.go
+++ b/task_test.go
@@ -58,7 +58,8 @@ func TestTask_OneGood(t *testing.T) {
 	case <-group.C:
 		assert.Fail(t, "group is signalled")
 	}
-	assert.NoError(t, group.SignalAndWait())
+	group.Signal()
+	assert.NoError(t, group.Wait())
 }
 
 func TestTask_TwoGood(t *testing.T) {
@@ -78,7 +79,8 @@ func TestTask_TwoGood(t *testing.T) {
 	case <-group.C:
 		assert.Fail(t, "group is signalled")
 	}
-	assert.NoError(t, group.SignalAndWait())
+	group.Signal()
+	assert.NoError(t, group.Wait())
 }
 
 func TestTask_OneBad(t *testing.T) {


### PR DESCRIPTION
Add WaitTimeout function to Group type.
Remove SignalAndWait function.
Upgrade to Go v1.15 and latest dependencies.